### PR TITLE
chore: update contributing guide Node 10 -> Node 12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Snazzy, we're always up for fancy new things! If the feature is fairly minor [cr
 You'll need a few things installed in order to update and test **map-workspaces** during development:
 
 
-* [node](https://nodejs.org/) v10 or greater
+* [node](https://nodejs.org/) v12.13.0 or greater
 
 > We recommend that you have a [node version manager](https://github.com/nvm-sh/nvm) installed if you plan on fixing bugs that might be present in a specific version of node. With a version manager you can easily switch versions of node and test if your changes to the CLI project are working.
 


### PR DESCRIPTION
Node.js 10 support was dropped in v2