### PR TITLE
fix: normalize backslashes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,6 +56,7 @@ function pkgPathmame (opts) {
 
 // make sure glob pattern only matches folders
 function getGlobPattern (pattern) {
+  pattern = pattern.replace(/\\/g, '/')
   return pattern.endsWith('/')
     ? pattern
     : `${pattern}/`

--- a/tap-snapshots/test/test.js.test.cjs
+++ b/tap-snapshots/test/test.js.test.cjs
@@ -5,6 +5,12 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/test.js TAP backslashes are normalized > matches with backslashes 1`] = `
+Map {
+  "a" => "{CWD}/test/tap-testdir-test-backslashes-are-normalized/packages/a",
+}
+`
+
 exports[`test/test.js TAP double negate patterns > should include doubly-negated items into resulting map 1`] = `
 Map {
   "a" => "{CWD}/test/tap-testdir-test-double-negate-patterns/packages/a",

--- a/test/test.js
+++ b/test/test.js
@@ -771,3 +771,25 @@ test('try to declare node_modules', t => {
     'should not include declared packages within node_modules'
   )
 })
+
+test('backslashes are normalized', t => {
+  const cwd = t.testdir({
+    packages: {
+      a: {
+        'package.json': '{ "name": "a" }',
+      },
+    },
+  })
+
+  return t.resolveMatchSnapshot(
+    mapWorkspaces({
+      cwd,
+      pkg: {
+        workspaces: [
+          'packages\\*',
+        ],
+      },
+    }),
+    'matches with backslashes'
+  )
+})


### PR DESCRIPTION
The next semver-major of minimatch does not allow backslashes.  We'll
normalize it here so that change doesn't break anyone currently relying
on that behavior