### PR TITLE
fix: evaluate all patterns before throwing `EDUPLICATEWORKSPACE`

### DIFF
--- a/tap-snapshots/test/test.js.test.cjs
+++ b/tap-snapshots/test/test.js.test.cjs
@@ -41,12 +41,41 @@ Map {
 }
 `
 
+exports[`test/test.js TAP match duplicates then exclude one > should include the non-excluded item on returned Map 1`] = `
+Map {
+  "a" => "{CWD}/test/tap-testdir-test-match-duplicates-then-exclude-one/packages/a",
+}
+`
+
+exports[`test/test.js TAP matched then negated then match again > should include item on returned Map 1`] = `
+Map {
+  "a" => "{CWD}/test/tap-testdir-test-matched-then-negated-then-match-again/packages/b/a",
+}
+`
+
+exports[`test/test.js TAP matched then negated then match again with wildcards > should exclude item on returned Map 1`] = `
+Map {}
+`
+
 exports[`test/test.js TAP missing pkg info > should return an empty map 1`] = `
 Array [
   Map {},
   Map {},
   Map {},
 ]
+`
+
+exports[`test/test.js TAP multiple duplicated workspaces config > should throw an error listing all duplicates 1`] = `
+Error: must not have multiple workspaces with the same name
+package 'a' has conflicts in the following paths:
+    {CWD}/test/tap-testdir-test-multiple-duplicated-workspaces-config/packages/a
+    {CWD}/test/tap-testdir-test-multiple-duplicated-workspaces-config/packages/b
+    {CWD}/test/tap-testdir-test-multiple-duplicated-workspaces-config/packages/c
+package 'b' has conflicts in the following paths:
+    {CWD}/test/tap-testdir-test-multiple-duplicated-workspaces-config/packages/d
+    {CWD}/test/tap-testdir-test-multiple-duplicated-workspaces-config/packages/e {
+  "code": "EDUPLICATEWORKSPACE",
+}
 `
 
 exports[`test/test.js TAP multiple negate patterns > should not include any negated pattern 1`] = `


### PR DESCRIPTION
# Motivation
Currently, if duplicates packages are included by the `n`-th pattern of the `workspaces` field of a `package.json`, the algorithm will throw an `EDUPLICATEWORKSPACE` without evaluating the other patterns.

So, for example, if the `n+1`-th pattern excludes all the duplicates, the workspaces should be considered valid.

# Reflexion

This is I think important because the `workspaces` field is described as an array of file patterns [^1].
The most historic occurrence to my knowledge of 'file pattern' for the package.json is the `files` field, and the behavior of those patterns is described as such:
> File patterns follow a similar syntax to .gitignore [^2]

The Git documentation explains that the '!' prefix is like this:
> An optional prefix "!" which negates the pattern; any matching file excluded by a previous pattern will become included again [^3]

I think that the keyword here is '_previous_'. This means the patterns do need to be evaluated sequentially (so for example, we cannot leverage the `ignore` options of `glob`, otherwise subsequent inclusion would not work).

# Proposed solution

Short: Evaluate all patterns sequentially and check for duplicates at the end. List all duplicates on error.
Longish:
We evaluate the patterns one by one. At each match, we either store or remove the path from a Set associated with the packageName, depending on if the pattern is an exclusive or inclusive one.
Once that's done, we got a `Map<Name,Set<PackagePath>>`.

We go through the Map entries to evaluate the presence of duplicates. If there's none for the current entries, we copy its key and the sole value of its associated Set to the result map (if the Set is empty, we skip the entry).
If there's a duplicate, we generate an error message stub and append it to the error array.
Here's that a choice I made:

- Either we 'fail-fast' and provide only the first duplicate pair.
  - Pro: Faster to fail
  - Con: If the end-user has more than one duplicate, it will need to repeat the operation.

- Either fail at the end and provide all the duplicates.  
  - Pro: Exhaustive error, the user has all the information to go from ❌ to ✔️ in just 1 run.
  - Con: Slower to fail.
  
My personal preference leans towards the exhaustive error message, so I used it in this PR.

Finally, if the error array is not empty (ish, we check `length>1` to ignore the 'header' of the error message), throw an `EDUPLICATEWORKSPACE` with a message from the concatenated error array. If there's no error, return the result array

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

[^1]: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#workspaces
[^2]: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files
[^3]: https://git-scm.com/docs/gitignore