### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ function appendNegatedPatterns (patterns) {
   for (let pattern of patterns) {
     const excl = pattern.match(/^!+/)
     if (excl) {
-      pattern = pattern.substr(excl[0].length)
+      pattern = pattern.slice(excl[0].length)
     }
 
     // strip off any / from the start of the pattern.  /foo => foo


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.