### PR TITLE
fix: faster workspace mapping

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -127,7 +127,16 @@ async function mapWorkspaces (opts = {}) {
   // preserves glob@8 behavior
   matches = matches.sort((a, b) => a.localeCompare(b, 'en'))
 
-  for (const match of matches) {
+  // we must preserve the order of results according to the given list of
+  // workspace patterns
+  const orderedMatches = []
+  for (const pattern of patterns) {
+    orderedMatches.push(...matches.filter((m) => {
+      return minimatch(m, pattern, { partial: true, windowsPathsNoEscape: true })
+    }))
+  }
+
+  for (const match of orderedMatches) {
     let pkg
     const packageJsonPathname = getPackagePathname(match, 'package.json')
 
@@ -172,8 +181,7 @@ async function mapWorkspaces (opts = {}) {
     })
   }
 
-  const sortedResults = Array.from(results.entries()).sort((a, b) => a[0].localeCompare(b[0], 'en'))
-  return new Map(sortedResults)
+  return results
 }
 
 function addDuplicateErrorMessages (messageArray, packageName, packagePathnames) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,10 @@ const { minimatch } = require('minimatch')
 const rpj = require('read-package-json-fast')
 const { glob } = require('glob')
 
-function appendNegatedPatterns (patterns) {
-  const results = []
-  for (let pattern of patterns) {
+function appendNegatedPatterns (allPatterns) {
+  const patterns = []
+  const negatedPatterns = []
+  for (let pattern of allPatterns) {
     const excl = pattern.match(/^!+/)
     if (excl) {
       pattern = pattern.slice(excl[0].length)
@@ -18,10 +19,35 @@ function appendNegatedPatterns (patterns) {
 
     // an odd number of ! means a negated pattern.  !!foo ==> foo
     const negate = excl && excl[0].length % 2 === 1
-    results.push({ pattern, negate })
+    if (negate) {
+      negatedPatterns.push(pattern)
+    } else {
+      // remove negated patterns that appeared before this pattern to avoid
+      // ignoring paths that were matched afterwards
+      // e.g: ['packages/**', '!packages/b/**', 'packages/b/a']
+      // in the above list, the last pattern overrides the negated pattern
+      // right before it. In effect, the above list would become:
+      // ['packages/**', 'packages/b/a']
+      // The order matters here which is why we must do it inside the loop
+      // as opposed to doing it all together at the end.
+      for (let i = 0; i < negatedPatterns.length; ++i) {
+        const negatedPattern = negatedPatterns[i]
+        if (minimatch(pattern, negatedPattern)) {
+          negatedPatterns.splice(i, 1)
+        }
+      }
+      patterns.push(pattern)
+    }
   }
 
-  return results
+  // use the negated patterns to eagerly remove all the patterns that
+  // can be removed to avoid unnecessary crawling
+  for (const negated of negatedPatterns) {
+    for (const pattern of minimatch.match(patterns, negated)) {
+      patterns.splice(patterns.indexOf(pattern), 1)
+    }
+  }
+  return { patterns, negatedPatterns }
 }
 
 function getPatterns (workspaces) {
@@ -77,11 +103,11 @@ async function mapWorkspaces (opts = {}) {
   }
 
   const { workspaces = [] } = opts.pkg
-  const patterns = getPatterns(workspaces)
+  const { patterns, negatedPatterns } = getPatterns(workspaces)
   const results = new Map()
   const seen = new Map()
 
-  if (!patterns.length) {
+  if (!patterns.length && !negatedPatterns.length) {
     return results
   }
 
@@ -89,45 +115,41 @@ async function mapWorkspaces (opts = {}) {
     ...opts,
     ignore: [
       ...opts.ignore || [],
-      ...['**/node_modules/**'],
+      '**/node_modules/**',
+      // just ignore the negated patterns to avoid unnecessary crawling
+      ...negatedPatterns,
     ],
   })
 
   const getPackagePathname = pkgPathmame(opts)
 
-  for (const item of patterns) {
-    let matches = await glob(getGlobPattern(item.pattern), getGlobOpts())
-    // preserves glob@8 behavior
-    matches = matches.sort((a, b) => a.localeCompare(b, 'en'))
+  let matches = await glob(patterns.map((p) => getGlobPattern(p)), getGlobOpts())
+  // preserves glob@8 behavior
+  matches = matches.sort((a, b) => a.localeCompare(b, 'en'))
 
-    for (const match of matches) {
-      let pkg
-      const packageJsonPathname = getPackagePathname(match, 'package.json')
-      const packagePathname = path.dirname(packageJsonPathname)
+  for (const match of matches) {
+    let pkg
+    const packageJsonPathname = getPackagePathname(match, 'package.json')
 
-      try {
-        pkg = await rpj(packageJsonPathname)
-      } catch (err) {
-        if (err.code === 'ENOENT') {
-          continue
-        } else {
-          throw err
-        }
-      }
-
-      const name = getPackageName(pkg, packagePathname)
-
-      let seenPackagePathnames = seen.get(name)
-      if (!seenPackagePathnames) {
-        seenPackagePathnames = new Set()
-        seen.set(name, seenPackagePathnames)
-      }
-      if (item.negate) {
-        seenPackagePathnames.delete(packagePathname)
+    try {
+      pkg = await rpj(packageJsonPathname)
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        continue
       } else {
-        seenPackagePathnames.add(packagePathname)
+        throw err
       }
     }
+
+    const packagePathname = path.dirname(packageJsonPathname)
+    const name = getPackageName(pkg, packagePathname)
+
+    let seenPackagePathnames = seen.get(name)
+    if (!seenPackagePathnames) {
+      seenPackagePathnames = new Set()
+      seen.set(name, seenPackagePathnames)
+    }
+    seenPackagePathnames.add(packagePathname)
   }
 
   const errorMessageArray = ['must not have multiple workspaces with the same name']
@@ -177,30 +199,25 @@ mapWorkspaces.virtual = function (opts = {}) {
   const { workspaces = [] } = packages[''] || {}
   // uses a pathname-keyed map in order to negate the exact items
   const results = new Map()
-  const patterns = getPatterns(workspaces)
-  if (!patterns.length) {
+  const { patterns, negatedPatterns } = getPatterns(workspaces)
+  if (!patterns.length && !negatedPatterns.length) {
     return results
   }
-  patterns.push({ pattern: '**/node_modules/**', negate: true })
+  negatedPatterns.push('**/node_modules/**')
+
+  const packageKeys = Object.keys(packages)
+  for (const pattern of negatedPatterns) {
+    for (const packageKey of minimatch.match(packageKeys, pattern)) {
+      packageKeys.splice(packageKeys.indexOf(packageKey), 1)
+    }
+  }
 
   const getPackagePathname = pkgPathmame(opts)
-
-  for (const packageKey of Object.keys(packages)) {
-    if (packageKey === '') {
-      continue
-    }
-
-    for (const item of patterns) {
-      if (minimatch(packageKey, item.pattern)) {
-        const packagePathname = getPackagePathname(packageKey)
-        const name = getPackageName(packages[packageKey], packagePathname)
-
-        if (item.negate) {
-          results.delete(packagePathname)
-        } else {
-          results.set(packagePathname, name)
-        }
-      }
+  for (const pattern of patterns) {
+    for (const packageKey of minimatch.match(packageKeys, pattern)) {
+      const packagePathname = getPackagePathname(packageKey)
+      const name = getPackageName(packages[packageKey], packagePathname)
+      results.set(packagePathname, name)
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -172,7 +172,8 @@ async function mapWorkspaces (opts = {}) {
     })
   }
 
-  return results
+  const sortedResults = Array.from(results.entries()).sort((a, b) => a[0].localeCompare(b[0], 'en'))
+  return new Map(sortedResults)
 }
 
 function addDuplicateErrorMessages (messageArray, packageName, packagePathnames) {

--- a/tap-snapshots/test/test.js.test.cjs
+++ b/tap-snapshots/test/test.js.test.cjs
@@ -156,3 +156,14 @@ Map {
   "b" => "{CWD}/test/tap-testdir-test-workspaces-config-using-simplistic-glob/packages/b",
 }
 `
+
+exports[`test/test.js TAP workspaces order > should match the exact order of workspaces 1`] = `
+Map {
+  "@npmcli/docs" => "{CWD}/test/tap-testdir-test-workspaces-order/docs",
+  "@npmcli/smoke-tests" => "{CWD}/test/tap-testdir-test-workspaces-order/smoke-tests",
+  "@npmcli/mock-registry" => "{CWD}/test/tap-testdir-test-workspaces-order/mock-registry",
+  "@npmcli/mock-globals" => "{CWD}/test/tap-testdir-test-workspaces-order/mock-globals",
+  "a" => "{CWD}/test/tap-testdir-test-workspaces-order/workspaces/a",
+  "b" => "{CWD}/test/tap-testdir-test-workspaces-order/workspaces/b",
+}
+`

--- a/tap-snapshots/test/test.js.test.cjs
+++ b/tap-snapshots/test/test.js.test.cjs
@@ -96,9 +96,9 @@ Map {
 
 exports[`test/test.js TAP nested node_modules > should ignore packages within node_modules 1`] = `
 Map {
+  "e" => "{CWD}/test/tap-testdir-test-nested-node_modules/foo/bar/baz/e",
   "a" => "{CWD}/test/tap-testdir-test-nested-node_modules/packages/a",
   "b" => "{CWD}/test/tap-testdir-test-nested-node_modules/packages/b",
-  "e" => "{CWD}/test/tap-testdir-test-nested-node_modules/foo/bar/baz/e",
 }
 `
 
@@ -116,8 +116,8 @@ Map {
 
 exports[`test/test.js TAP root declared within workspaces > should allow the root package to be declared within workspaces 1`] = `
 Map {
-  "a" => "{CWD}/test/tap-testdir-test-root-declared-within-workspaces/packages/a",
   "root-workspace" => "{CWD}/test/tap-testdir-test-root-declared-within-workspaces",
+  "a" => "{CWD}/test/tap-testdir-test-root-declared-within-workspaces/packages/a",
 }
 `
 

--- a/tap-snapshots/test/test.js.test.cjs
+++ b/tap-snapshots/test/test.js.test.cjs
@@ -96,9 +96,9 @@ Map {
 
 exports[`test/test.js TAP nested node_modules > should ignore packages within node_modules 1`] = `
 Map {
-  "e" => "{CWD}/test/tap-testdir-test-nested-node_modules/foo/bar/baz/e",
   "a" => "{CWD}/test/tap-testdir-test-nested-node_modules/packages/a",
   "b" => "{CWD}/test/tap-testdir-test-nested-node_modules/packages/b",
+  "e" => "{CWD}/test/tap-testdir-test-nested-node_modules/foo/bar/baz/e",
 }
 `
 
@@ -116,8 +116,8 @@ Map {
 
 exports[`test/test.js TAP root declared within workspaces > should allow the root package to be declared within workspaces 1`] = `
 Map {
-  "root-workspace" => "{CWD}/test/tap-testdir-test-root-declared-within-workspaces",
   "a" => "{CWD}/test/tap-testdir-test-root-declared-within-workspaces/packages/a",
+  "root-workspace" => "{CWD}/test/tap-testdir-test-root-declared-within-workspaces",
 }
 `
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This PR changes the workspace finding algorithm to be around 2x faster by:

1. `glob`ing only once instead of for each pattern
2. Using `ignore` in `glob` for negated patterns

The results on my machine look quite good:
```
┌─────────┬───────────────┬──────────┬────────────────────┬───────────┬─────────┐
│ (index) │   Task Name   │ ops/sec  │ Average Time (ns)  │  Margin   │ Samples │
├─────────┼───────────────┼──────────┼────────────────────┼───────────┼─────────┤
│    0    │     'old'     │   '97'   │ 10300189.995765686 │ '±58.58%' │   10    │
│    1    │     'new'     │  '195'   │ 5119704.985618591  │ '±6.59%'  │   20    │
│    2    │ 'new virtual' │ '24,096' │  41499.5856304881  │ '±3.61%'  │  2410   │
│    3    │ 'old virtual' │ '54,503' │ 18347.38597894367  │ '±1.64%'  │  5451   │
└─────────┴───────────────┴──────────┴────────────────────┴───────────┴─────────┘
```

This PR doesn't break any test or introduce any new package.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
