### PR TITLE
docs(readme): fix broken badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # @npmcli/map-workspaces
 
 [![NPM version](https://img.shields.io/npm/v/@npmcli/map-workspaces)](https://www.npmjs.com/package/@npmcli/map-workspaces)
-[![Build Status](https://img.shields.io/github/workflow/status/npm/map-workspaces/node-ci)](https://github.com/npm/map-workspaces)
-[![License](https://img.shields.io/github/license/npm/map-workspaces)](https://github.com/npm/map-workspaces/blob/master/LICENSE)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/npm/map-workspaces/ci.yml?branch=main)](https://github.com/npm/map-workspaces)
+[![License](https://img.shields.io/npm/l/@npmcli/map-workspaces)](https://github.com/npm/map-workspaces/blob/main/LICENSE.md)
 
 Retrieves a name:pathname Map for a given workspaces config.
 


### PR DESCRIPTION
### Before

[![Build Status](https://img.shields.io/github/workflow/status/npm/map-workspaces/node-ci)](https://github.com/npm/map-workspaces)
[![License](https://img.shields.io/github/license/npm/map-workspaces)](https://github.com/npm/map-workspaces/blob/master/LICENSE)

### After

[![Build Status](https://img.shields.io/github/actions/workflow/status/npm/map-workspaces/ci.yml?branch=main)](https://github.com/npm/map-workspaces)
[![License](https://img.shields.io/npm/l/@npmcli/map-workspaces)](https://github.com/npm/map-workspaces/blob/main/LICENSE.md)

## References

Related to npm/template-oss#426
