### PR TITLE
fix: allow for workspace patterns to start with `./`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,8 +14,8 @@ function appendNegatedPatterns (allPatterns) {
       pattern = pattern.slice(excl[0].length)
     }
 
-    // strip off any / from the start of the pattern.  /foo => foo
-    pattern = pattern.replace(/^\/+/, '')
+    // strip off any / or ./ from the start of the pattern.  /foo => foo
+    pattern = pattern.replace(/^\.?\/+/, '')
 
     // an odd number of ! means a negated pattern.  !!foo ==> foo
     const negate = excl && excl[0].length % 2 === 1

--- a/tap-snapshots/test/test.js.test.cjs
+++ b/tap-snapshots/test/test.js.test.cjs
@@ -156,6 +156,12 @@ Map {
 }
 `
 
+exports[`test/test.js TAP workspaces config using relative path globs > should return a valid map 1`] = `
+Map {
+  "a" => "{CWD}/test/tap-testdir-test-workspaces-config-using-relative-path-globs/packages/a",
+}
+`
+
 exports[`test/test.js TAP workspaces config using simplistic glob > should return a valid map 1`] = `
 Map {
   "a" => "{CWD}/test/tap-testdir-test-workspaces-config-using-simplistic-glob/packages/a",

--- a/test/test.js
+++ b/test/test.js
@@ -140,6 +140,34 @@ test('workspaces config using simplistic glob', t => {
   )
 })
 
+test('workspaces config using relative path globs', t => {
+  const cwd = t.testdir({
+    packages: {
+      a: {
+        'package.json': '{ "name": "a" }',
+      },
+      b: {
+        'package.json': '{ "name": "b" }',
+      },
+    },
+  })
+
+  return t.resolveMatchSnapshot(
+    mapWorkspaces({
+      cwd,
+      pkg: {
+        workspaces: {
+          packages: [
+            './packages/*',
+            '!./packages/b',
+          ],
+        },
+      },
+    }),
+    'should return a valid map'
+  )
+})
+
 test('duplicated workspaces config', t => {
   const cwd = t.testdir({
     packages: {


### PR DESCRIPTION
Closes https://github.com/npm/map-workspaces/issues/144