### PR TITLE
fix!: Address breaking engine change in dependency

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -87,8 +87,6 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 14.17.0
-          - 14.x
           - 16.13.0
           - 16.x
           - 18.0.0
@@ -96,10 +94,6 @@ jobs:
           - 20.x
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-latest, shell: bash }
-            node-version: 14.17.0
-          - platform: { name: macOS, os: macos-latest, shell: bash }
-            node-version: 14.x
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 16.13.0
           - platform: { name: macOS, os: macos-13, shell: bash }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,6 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 14.17.0
-          - 14.x
           - 16.13.0
           - 16.x
           - 18.0.0
@@ -73,10 +71,6 @@ jobs:
           - 20.x
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-latest, shell: bash }
-            node-version: 14.17.0
-          - platform: { name: macOS, os: macos-latest, shell: bash }
-            node-version: 14.x
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 16.13.0
           - platform: { name: macOS, os: macos-13, shell: bash }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib/"
   ],
   "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+    "node": "^16.13.0 || >=18.0.0"
   },
   "description": "Retrieves a name:pathname Map for a given workspaces config",
   "repository": {
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@npmcli/name-from-folder": "^2.0.0",
-    "glob": "^10.2.2",
+    "glob": "^10.4.5",
     "minimatch": "^9.0.0",
     "read-package-json-fast": "^3.0.0"
   },


### PR DESCRIPTION
<!---
# Before Opening Please...
- [ ] Read our CONTRIBUTING.md
- [ ] Provide a general summary of the feature in the Title above
- [ ] Ensure your fix is complete
- [ ] Ensure your PR has updated docs if functional changes were made
- [ ] Ensure your PR has tests that will break/error without your fix
- [ ] Ensure your PR has labels
- [ ] Ensure your PR has reviewers outlined
-->

## Description

Remove Node 14 from `engines`. node 14.17.x no longer works due to https://github.com/isaacs/node-glob/commit/435d1f7acd78a00c9dab2a7f6489155c7caac97c. If this change is approved, I intend to apply the same change to other `npm-cli` repos that use `glob@10`.

Alternative solutions:
* Increase the min engine version for Node 14 to `^14.18.0`. In the past this has been considered a breaking change, and requires increase of the major version. However `engines` is already inaccurate if you install the latest version of `glob@10`. 🤔 
* Pin to `glob@10.3.12` to keep node 14.17.x working. However we'll lose the fix for https://github.com/isaacs/node-glob/issues/584

Discovered via the CI for https://github.com/npm/map-workspaces/pull/162