### PR TITLE
fix: Update `engines` to handle `node:` prefix

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -87,7 +87,7 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 14.17.0
+          - 14.18.0
           - 14.x
           - 16.13.0
           - 16.x
@@ -97,7 +97,7 @@ jobs:
           - 22.x
         exclude:
           - platform: { name: macOS, os: macos-latest, shell: bash }
-            node-version: 14.17.0
+            node-version: 14.18.0
           - platform: { name: macOS, os: macos-latest, shell: bash }
             node-version: 14.x
           - platform: { name: macOS, os: macos-13, shell: bash }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 14.17.0
+          - 14.18.0
           - 14.x
           - 16.13.0
           - 16.x
@@ -74,7 +74,7 @@ jobs:
           - 22.x
         exclude:
           - platform: { name: macOS, os: macos-latest, shell: bash }
-            node-version: 14.17.0
+            node-version: 14.18.0
           - platform: { name: macOS, os: macos-latest, shell: bash }
             node-version: 14.x
           - platform: { name: macOS, os: macos-13, shell: bash }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib/"
   ],
   "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+    "node": "^14.18.0 || ^16.13.0 || >=18.0.0"
   },
   "description": "Retrieves a name:pathname Map for a given workspaces config",
   "repository": {


### PR DESCRIPTION
<!---
# Before Opening Please...
- [ ] Read our CONTRIBUTING.md
- [ ] Provide a general summary of the feature in the Title above
- [ ] Ensure your fix is complete
- [ ] Ensure your PR has updated docs if functional changes were made
- [ ] Ensure your PR has tests that will break/error without your fix
- [ ] Ensure your PR has labels
- [ ] Ensure your PR has reviewers outlined
-->

## Description

If you install the latest versions of this package's dependencies, node 14.17.x no longer works due to a `node:` prefix being added in https://github.com/isaacs/node-glob/commit/435d1f7acd78a00c9dab2a7f6489155c7caac97c. `node: import` support was added to node 14.18.0 ([ref](https://nodejs.org/docs/latest-v14.x/api/modules.html#modules_core_modules)).

I'd prefer to fix the build break for the current major version of this package, before we release a new major version. The options I see are:

1. Pin to `glob@10.3.12` to get node 14.17.x working again. However we'll lose the fix for https://github.com/isaacs/node-glob/issues/584. And there probably wouldn't be a simple path for 14.latest consumers to get that fix back, as we might drop node 14 in the next major version.
2. Update `engines` to reflect **reality**, _without_ changing the major version.
3. Do nothing with regards to the current major version.

I went with Option 2. If this package still has node 14 consumers, I'm hoping they're using 14.latest or can move to ^14.18.0.

If we agree on this path forward, I intend to apply the same change to several other `npm-cli` repos using `glob@10`.