### PR TITLE
fix: workspaces run at root

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,20 @@ const { minimatch } = require('minimatch')
 const pkgJson = require('@npmcli/package-json')
 const { glob } = require('glob')
 
+function removeRootPath (location) {
+  const sep = location.split(path.sep)
+
+  /* istanbul ignore next */
+  /**
+   * it's not feasible to test the codepath where cwd is root `/`
+   * tap doesn't support it and an attempt with mock-fs broke nyc
+  */
+  if (sep[0] === '') {
+    sep.shift()
+  }
+  return path.join(...sep)
+}
+
 function appendNegatedPatterns (allPatterns) {
   const patterns = []
   const negatedPatterns = []
@@ -125,7 +139,7 @@ async function mapWorkspaces (opts = {}) {
   const orderedMatches = []
   for (const pattern of patterns) {
     orderedMatches.push(...matches.filter((m) => {
-      return minimatch(m, pattern, { partial: true, windowsPathsNoEscape: true })
+      return minimatch(removeRootPath(m), pattern, { partial: true, windowsPathsNoEscape: true })
     }))
   }
 


### PR DESCRIPTION
I was looking into https://github.com/npm/cli/issues/7563 where `npm run -w packages/workspace` [doesn't work when the cwd is root / (docker issue)](https://github.com/npm/cli/issues/7563). 

Turns out it's because this returns false here https://github.com/npm/map-workspaces/blob/main/lib/index.js#L128

```js
minimatch('/packages/workspace','packages/workspace', { partial: true, windowsPathsNoEscape: true })
```

I wish we could catch these. It is not possible to test this kind of code that uses cwd `/`. 