### PR TITLE
fix: ignore `ENOTDIR` errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,7 +134,7 @@ async function mapWorkspaces (opts = {}) {
     try {
       pkg = await pkgJson.normalize(path.join(opts.cwd, match))
     } catch (err) {
-      if (err.code === 'ENOENT') {
+      if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
         continue
       } else {
         throw err

--- a/tap-snapshots/test/test.js.test.cjs
+++ b/tap-snapshots/test/test.js.test.cjs
@@ -41,6 +41,12 @@ Map {
 }
 `
 
+exports[`test/test.js TAP ignore symlink workspace files > should not throw an error 1`] = `
+Map {
+  "a" => "{CWD}/test/tap-testdir-test-ignore-symlink-workspace-files/packages/a",
+}
+`
+
 exports[`test/test.js TAP match duplicates then exclude one > should include the non-excluded item on returned Map 1`] = `
 Map {
   "a" => "{CWD}/test/tap-testdir-test-match-duplicates-then-exclude-one/packages/a",

--- a/test/test.js
+++ b/test/test.js
@@ -980,3 +980,29 @@ test('match duplicates then exclude one', t => {
     'should include the non-excluded item on returned Map'
   )
 })
+
+test('ignore symlink workspace files', t => {
+    const cwd = t.testdir({
+        'index.js': 'console.log("hi");',
+        packages: {
+            a: {
+                'package.json': '{ "name": "a" }',
+                'index.js': t.fixture('symlink', '../../index.js')
+            },
+        },
+    })
+
+    return t.resolveMatchSnapshot(
+            mapWorkspaces({
+                cwd,
+                pkg: {
+                    workspaces: {
+                        packages: [
+                            'packages/**',
+                        ],
+                    },
+                },
+            }),
+            'should not throw an error'
+    )
+})


### PR DESCRIPTION
Fixed a bug with `map-workspaces` over-aggressively inspecting symbolic links to files as workspaces. When this happens, an `ENOTDIR` error is thrown. We should be able to safely ignore that error just like `ENOENT`, which fixes the root cause of the referenced bug.

fixes https://github.com/npm/cli/issues/7834